### PR TITLE
Allow add www prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Features
 - [x] Force Https to specific routes only.
 - [x] Keep headers, request method, and request body.
 - [x] Enable/disable HTTP Strict Transport Security Header and set its value.
+- [x] Allow add "www." prefix during redirection.
 
 Installation
 ------------
@@ -75,6 +76,7 @@ return [
             'enable' => true, // set to false to disable it
             'value'  => 'max-age=31536000',
         ],
+        'add_www_prefix'        => false, // set to true to add "www." prefix during redirection
     ],
     // ...
 ];

--- a/config/expressive-force-https-module.local.php.dist
+++ b/config/expressive-force-https-module.local.php.dist
@@ -15,6 +15,7 @@ return [
             'enable' => true, // set to false to disable it
             'value'  => 'max-age=31536000',
         ],
+        'add_www_prefix'        => false,
     ],
 
     'dependencies' => [

--- a/config/force-https-module.local.php.dist
+++ b/config/force-https-module.local.php.dist
@@ -13,5 +13,6 @@ return [
             'enable' => true, // set to false to disable it
             'value'  => 'max-age=31536000',
         ],
+        'add_www_prefix'        => false,
     ],
 ];

--- a/spec/Listener/ForceHttpsSpec.php
+++ b/spec/Listener/ForceHttpsSpec.php
@@ -211,6 +211,37 @@ describe('ForceHttps', function () {
 
             });
 
+            it('redirect with www prefix with configurable "add_www_prefix" on force_all_routes', function () {
+
+                $listener = new ForceHttps([
+                    'enable'                => true,
+                    'force_all_routes'      => true,
+                    'force_specific_routes' => [],
+                    'strict_transport_security' => [
+                        'enable' => true,
+                        'value' => 'max-age=31536000',
+                    ],
+                    'add_www_prefix' => true,
+                ]);
+
+                allow($this->mvcEvent)->toReceive('getRequest')->andReturn($this->request);
+                allow($this->request)->toReceive('getUri')->andReturn($this->uri);
+                allow($this->uri)->toReceive('getScheme')->andReturn('http');
+                allow($this->mvcEvent)->toReceive('getRouteMatch', 'getMatchedRouteName')->andReturn('about');
+                allow($this->uri)->toReceive('setScheme')->with('https')->andReturn($this->uri);
+                allow($this->uri)->toReceive('toString')->andReturn('https://example.com/about');
+                allow($this->mvcEvent)->toReceive('getResponse')->andReturn($this->response);
+                allow($this->response)->toReceive('setStatusCode')->with(308)->andReturn($this->response);
+                allow($this->response)->toReceive('getHeaders', 'addHeaderLine')->with('Location', 'https://example.com/about');
+                allow($this->response)->toReceive('send');
+
+                $listener->forceHttpsScheme($this->mvcEvent);
+
+                expect($this->mvcEvent)->toReceive('getResponse');
+                expect($this->response)->toReceive('getHeaders', 'addHeaderLine')->with('Location', 'https://www.example.com/about');
+
+            });
+
             it('not redirect with set strict_transport_security exists and uri already has https scheme', function () {
 
                 $listener = new ForceHttps([

--- a/spec/Middleware/ForceHttpsSpec.php
+++ b/spec/Middleware/ForceHttpsSpec.php
@@ -169,6 +169,7 @@ describe('ForceHttps', function () {
 
             allow($this->router)->toReceive('match')->andReturn($match);
             allow($this->request)->toReceive('getUri', 'getScheme')->andReturn('http');
+            allow($this->request)->toReceive('getUri', 'withScheme', '__toString')->andReturn('https://example.com/about');
 
             allow($this->response)->toReceive('withStatus')->andReturn($this->response);
 
@@ -187,6 +188,7 @@ describe('ForceHttps', function () {
             $listener->__invoke($this->request, $this->response, function () {});
 
             expect($this->response)->toReceive('withStatus')->with(308);
+            expect($this->response)->toReceive('withHeader')->with('Location', 'https://example.com/about');
 
         });
 
@@ -197,6 +199,7 @@ describe('ForceHttps', function () {
 
             allow($this->router)->toReceive('match')->andReturn($match);
             allow($this->request)->toReceive('getUri', 'getScheme')->andReturn('http');
+            allow($this->request)->toReceive('getUri', 'withScheme', '__toString')->andReturn('https://example.com/about');
 
             allow($this->response)->toReceive('withStatus')->andReturn($this->response);
 
@@ -216,6 +219,7 @@ describe('ForceHttps', function () {
             $listener->__invoke($this->request, $this->response, function () {});
 
             expect($this->response)->toReceive('withStatus')->with(308);
+            expect($this->response)->toReceive('withHeader')->with('Location', 'https://www.example.com/about');
 
         });
 

--- a/spec/Middleware/ForceHttpsSpec.php
+++ b/spec/Middleware/ForceHttpsSpec.php
@@ -190,6 +190,35 @@ describe('ForceHttps', function () {
 
         });
 
+        it('return Response with 308 status with include www prefix on http and match with configurable "add_www_prefix"', function () {
+
+            Console::overrideIsConsole(false);
+            $match = RouteResult::fromRoute(new Route('/about', 'About'));
+
+            allow($this->router)->toReceive('match')->andReturn($match);
+            allow($this->request)->toReceive('getUri', 'getScheme')->andReturn('http');
+
+            allow($this->response)->toReceive('withStatus')->andReturn($this->response);
+
+            $listener = new ForceHttps(
+                [
+                    'enable' => true,
+                    'force_all_routes' => true,
+                    'strict_transport_security' => [
+                        'enable' => true,
+                        'value'  => 'max-age=31536000',
+                    ],
+                    'add_www_prefix' => true,
+                ],
+                $this->router
+            );
+
+            $listener->__invoke($this->request, $this->response, function () {});
+
+            expect($this->response)->toReceive('withStatus')->with(308);
+
+        });
+
     });
 
 });

--- a/src/HttpsTrait.php
+++ b/src/HttpsTrait.php
@@ -56,4 +56,26 @@ trait HttpsTrait
 
         return true;
     }
+
+    /**
+     * Add www. prefix when required in the config
+     *
+     * @param  string $httpsRequestUri
+     * @return string
+     */
+    private function withWwwPrefixWhenRequired($httpsRequestUri)
+    {
+        if (
+            ! isset($this->config['add_www_prefix']) ||
+            ! $this->config['add_www_prefix'] ||
+            (
+                $this->config['add_www_prefix'] === true &&
+                substr($httpsRequestUri, 8, 4) === 'www.'
+            )
+        ) {
+            return $httpsRequestUri;
+        }
+
+        return str_replace('https://', 'https://www.', $httpsRequestUri);
+    }
 }

--- a/src/Listener/ForceHttps.php
+++ b/src/Listener/ForceHttps.php
@@ -97,7 +97,7 @@ class ForceHttps extends AbstractListenerAggregate
 
         /** @var $response \Zend\Http\PhpEnvironment\Response */
         $response        = $e->getResponse();
-        $httpsRequestUri = $uri->setScheme('https')->toString();
+        $httpsRequestUri = $this->withWwwPrefixWhenRequired($uri->setScheme('https')->toString());
 
         // 307 keeps headers, request method, and request body
         // \Zend\Http\PhpEnvironment\Response doesn't support 308 yet

--- a/src/Middleware/ForceHttps.php
+++ b/src/Middleware/ForceHttps.php
@@ -74,7 +74,7 @@ class ForceHttps
         }
 
         $newUri          = $uri->withScheme('https');
-        $httpsRequestUri = $newUri->__toString();
+        $httpsRequestUri = $this->withWwwPrefixWhenRequired($newUri->__toString());
 
         // 308 keeps headers, request method, and request body
         // \Zend\Diactoros\Response already support 308


### PR DESCRIPTION
It now can be configurable:

```php
return [
    'force-https-module' => [
         // other config here ...
         'add_www_prefix'        => true,
    ],
];
```

So, when we open 'http://example.com' it will be redirected to 'https://www.example.com'