### PR TITLE
18: Added exclude_specific_routes config option to exclude a certain …

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Features
 - [x] Enable/disable force https.
 - [x] Force Https to All routes.
 - [x] Force Https to specific routes only.
+- [x] Force Https to all routes except exclusion list.
 - [x] Keep headers, request method, and request body.
 - [x] Enable/disable HTTP Strict Transport Security Header and set its value.
 - [x] Allow add `www.` prefix during redirection from http or already https.
@@ -76,6 +77,11 @@ return [
             // only works if previous's config 'force_all_routes' => false
             'checkout',
             'payment'
+        ],
+        'exclude_specific_routes' => [
+            // a lists of specific routes to not be https
+            // only works if previous config 'force_all_routes' => true
+            'non-https-route',
         ],
         // set HTTP Strict Transport Security Header
         'strict_transport_security' => [

--- a/config/expressive-force-https-module.local.php.dist
+++ b/config/expressive-force-https-module.local.php.dist
@@ -10,6 +10,10 @@ return [
             // a lists of specific routes to be https
             // only works if previous config 'force_all_routes' => false
         ],
+        'exclude_specific_routes' => [
+            // a lists of specific routes to not be https
+            // only works if previous config 'force_all_routes' => true
+        ],
         // set HTTP Strict Transport Security Header
         'strict_transport_security' => [
             'enable' => true, // set to false to disable it

--- a/config/force-https-module.local.php.dist
+++ b/config/force-https-module.local.php.dist
@@ -8,6 +8,10 @@ return [
             // a lists of specific routes to be https
             // only works if previous config 'force_all_routes' => false
         ],
+        'exclude_specific_routes' => [
+            // a lists of specific routes to not be https
+            // only works if previous config 'force_all_routes' => true
+        ],
         // set HTTP Strict Transport Security Header
         'strict_transport_security' => [
             'enable' => true, // set to false to disable it

--- a/src/HttpsTrait.php
+++ b/src/HttpsTrait.php
@@ -35,6 +35,11 @@ trait HttpsTrait
         }
 
         if ($this->config['force_all_routes']) {
+            if (! empty($this->config['exclude_specific_routes'])
+                && \in_array($match->getMatchedRouteName(), $this->config['exclude_specific_routes'])) {
+                return false;
+            }
+
             return true;
         }
 


### PR DESCRIPTION
What is currently missing is the ability to support the exclusion list to force https everywhere except some edge case routes. We got a valid use case for that when dealing with external sites embedded as an iframe. Without a protocol match, the iframe will not be displayed